### PR TITLE
Stable release: add combinators, helpers and nullability patterns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: csharp
 mono: 5.2.0
 dotnet: 2.0.0
 dist: trusty
+sudo: true
 script:
   - bash build.sh

--- a/build.fsx
+++ b/build.fsx
@@ -8,7 +8,6 @@ let libPath = "./src"
 let testsPath = "./integration-tests"
 let databaseDockerContainerName = "npgsql_fsharp_db"
 let databaseDockerImageName = "npgsql_fsharp_image"
-
 let databasePassword = "postgres"
 
 
@@ -64,7 +63,6 @@ Target "Clean" <| fun _ ->
       libPath </> "bin"
       libPath </> "obj" ]
     |> CleanDirs
-
 
 
 Target "StartDatabase" (fun _ ->

--- a/integration-tests/Tests.fs
+++ b/integration-tests/Tests.fs
@@ -14,67 +14,104 @@ type Actor = {
 
 let defaultConnection() =
     Sql.host "localhost"
-    |> Sql.username "postgres" //(getEnv "PG_USER")
-    |> Sql.password "postgres" //(getEnv "PG_PASS")
-    |> Sql.database "dvdrental" //"sample_db"
+    |> Sql.port 5432
+    |> Sql.username "postgres" 
+    |> Sql.password "postgres"
+    |> Sql.database "dvdrental" 
     |> Sql.str
-    |> Sql.connect
 
 let handleInfinityConnection() =
     Sql.host "localhost"
-    |> Sql.username "postgres" //(getEnv "PG_USER")
-    |> Sql.password "postgres" //(getEnv "PG_PASS")
-    |> Sql.database "dvdrental" //"sample_db"
+    |> Sql.port 5432
+    |> Sql.username "postgres"
+    |> Sql.password "postgres" 
+    |> Sql.database "dvdrental"
     |> Sql.config "Convert Infinity DateTime=true;"
     |> Sql.str
-    |> Sql.connect
+
+type OptionBuilder() =
+    member x.Bind(v,f) = Option.bind f v
+    member x.Return v = Some v
+    member x.ReturnFrom o = o
+    member x.Zero () = None
+
+let option = OptionBuilder()
 
 defaultConnection()
+|> Sql.connect
 |> Sql.query "SELECT * FROM \"actor\""
 |> Sql.executeTable
 |> Sql.mapEachRow (function
-    | [ "Id", Int id
-        "UserName", String first_name
-        "Password", String last_name
-        "LastUpdate", Date last_update] ->
+    | [ "Id", SqlValue.Int id
+        "UserName", SqlValue.String first_name
+        "Password", SqlValue.String last_name
+        "LastUpdate", SqlValue.Date last_update] ->
         let user = { Id = id; FirstName = first_name; LastName = last_name; LastUpdate = last_update }
         Some user
     | _ -> None)
 |> List.iter (fun user -> printfn "User %s %s was found" user.FirstName user.LastName)
 
+defaultConnection()
+|> Sql.connect
+|> Sql.query "SELECT * FROM \"actor\""
+|> Sql.executeTable
+|> List.iter (printfn "%A")
+
 
 defaultConnection()
+|> Sql.connect
 |> Sql.query "SELECT * FROM \"actor\""
 |> Sql.prepare
 |> Sql.executeTable
-|> Sql.mapEachRow (function
-    | [ "Id", Int id
-        "UserName", String first_name
-        "Password", String last_name
-        "LastUpdate", Date last_update] ->
-        let user = { Id = id; FirstName = first_name; LastName = last_name; LastUpdate = last_update }
-        Some user
-    | _ -> None)
-|> List.iter (fun user -> printfn "User %s %s was found" user.FirstName user.LastName)
+|> Sql.mapEachRow (fun row -> 
+    option {
+        let! id = Sql.readInt "actor_id" row
+        let! firstName = Sql.readString "first_name" row
+        let! lastName = Sql.readString "last_name" row 
+        let! lastUpdate = Sql.readDate "last_update" row
+        return { 
+            Id = id;
+            FirstName = firstName
+            LastName = lastName 
+            LastUpdate = lastUpdate
+        }
+    })
+|> printfn "%A"
 
 defaultConnection()
+|> Sql.connect
 |> Sql.func "film_in_stock"
-|> Sql.parameters ["p_film_id", Int 1; "p_store_id", Int 1]
+|> Sql.parameters [ "p_film_id", Sql.Value 1; "p_store_id", Sql.Value 1]
 |> Sql.executeScalar
 |> function
-    | Int 1 -> printfn "Film in stock as expected"
+    | SqlValue.Int 1 -> printfn "Film in stock as expected"
     | _ -> failwith "Expected result to be 1"
 
 
 defaultConnection()
+|> Sql.connect
 |> Sql.func "film_in_stock"
-|> Sql.parameters  ["p_film_id", Int 1; "p_store_id", Int 42]
+|> Sql.parameters  ["p_film_id", Sql.Value 1; "p_store_id", Sql.Value 42]
 |> Sql.executeScalar
 |> function
-    | Null ->  printfn "User was not found as expected"
+    | SqlValue.Null ->  printfn "User was not found as expected"
     | _ -> failwith "Table should not contain this '42' value"
 
+printfn "Null roundtrip start"
+
 defaultConnection()
+|> Sql.connect 
+|> Sql.query "SELECT @nullValue"
+|> Sql.parameters [ "nullValue", SqlValue.Null ]
+|> Sql.executeScalar
+|> function 
+    | SqlValue.Null -> printfn "Succesfully returned null"
+    | otherwise -> printfn "Unexpected %A" otherwise
+
+printfn "Null roundtrip end"
+
+defaultConnection()
+|> Sql.connect
 |> Sql.query "SELECT NOW()"
 |> Sql.executeScalar
 |> Sql.toDateTime
@@ -88,36 +125,15 @@ let storeMetadata =
      "where table_name = 'store'"]
 
 defaultConnection()
+|> Sql.connect
 |> Sql.queryMany [store; storeMetadata]
 |> Sql.executeMany
 |> List.iter (fun table ->
     printfn "Table:\n%A\n" table)
 
-// let sqlQuery = """
-// select * from
-//    -- group logs by request id
-//    (select json_agg(properties) as "Logs",
-//            properties->'Properties'->>'RequestId' as "RequestId"
-//     from logs
-//     group by properties->'Properties'->>'RequestId') requests
-
-// -- The first log is always the request log, so we filter here by Method
-// where "Logs"->0->'Properties'->>'Method' = 'POST'
-// """
-
-// Sql.host "localhost"
-// |> Sql.username (getEnv "PG_USER")
-// |> Sql.password (getEnv "PG_PASS")
-// |> Sql.database "Logs"
-// |> Sql.str
-// |> Sql.connect
-// |> Sql.query sqlQuery
-// |> Sql.executeTable
-// |> printfn "%A"
-
-
 
 defaultConnection()
+|> Sql.connect
 |> Sql.query "CREATE EXTENSION IF NOT EXISTS hstore"
 |> Sql.executeNonQuery
 |> printfn "Create Extention hstore returned %A"
@@ -126,17 +142,22 @@ let inputMap =
     ["property", "value from F#"]
     |> Map.ofSeq
 
+printfn "HStore roundtrip start"
+
 defaultConnection()
+|> Sql.connect
 |> Sql.query "select @map"
-|> Sql.parameters ["map", HStore inputMap]
+|> Sql.parameters ["map", Sql.Value inputMap]
 |> Sql.executeScalar
 |> function
-    | HStore map ->
+    | SqlValue.HStore map ->
         match Map.tryFind "property" map with
         | Some "value from F#" -> "Mapping HStore works"
         | _ -> "Something went wrong when reading HStore"
     | _ -> "Something went wrong when mapping HStore"
 |> printfn "%A"
+
+printfn "HStore roundtrip end"
 
 // Unhandled Exception: System.NotSupportedException: Npgsql 3.x removed support for writing a parameter with an IEnumerable value, use .ToList()/.ToArray() instead
 // Need to add a NpgsqlTypeHandler for Map ?
@@ -147,53 +168,60 @@ let bytesInput =
     |> Array.ofList
 
 defaultConnection()
+|> Sql.connect
 |> Sql.query "SELECT @manyBytes"
-|> Sql.parameters [ "manyBytes", Bytea bytesInput ]
+|> Sql.parameters [ "manyBytes", Sql.Value bytesInput ]
 |> Sql.executeScalar
 |> function
-    | Bytea output -> if (output <> bytesInput)
-                      then failwith "Bytea roundtrip failed, the output was different"
-                      else printfn "Bytea roundtrip worked"
+    | SqlValue.Bytea output -> 
+        if (output <> bytesInput)
+        then failwith "Bytea roundtrip failed, the output was different"
+        else printfn "Bytea roundtrip worked"
 
     | _ -> failwith "Bytea roundtrip failed"
-
 
 let guid = System.Guid.NewGuid()
 
 defaultConnection()
+|> Sql.connect
 |> Sql.query "SELECT @uuid_input"
-|> Sql.parameters [ "uuid_input", Uuid guid ]
+|> Sql.parameters [ "uuid_input", Sql.Value guid ]
 |> Sql.executeScalar
 |> function
-    | Uuid output -> if (output.ToString() <> guid.ToString())
-                      then failwith "Uuid roundtrip failed, the output was different"
-                      else printfn "Uuid roundtrip worked"
+    | SqlValue.Uuid output -> 
+        if (output.ToString() <> guid.ToString())
+        then failwith "Uuid roundtrip failed, the output was different"
+        else printfn "Uuid roundtrip worked"
 
     | _ -> failwith "Uuid roundtrip failed"
 
 
 defaultConnection()
+|> Sql.connect
 |> Sql.query "SELECT @money_input::money"
-|> Sql.parameters [ "money_input", Decimal 12.5M ]
+|> Sql.parameters [ "money_input", Sql.Value 12.5M ]
 |> Sql.executeScalar
 |> function
-    | Decimal 12.5M -> printfn "Money as decimal roundtrip worked"
+    | SqlValue.Decimal 12.5M -> printfn "Money as decimal roundtrip worked"
     | _ -> failwith "Money as decimal roundtrip failed"
 
 
 defaultConnection()
+|> Sql.connect
 |> Sql.query "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\""
 |> Sql.executeNonQuery
 |> printfn "Create Extention uuid-ossp returned %A"
 
 defaultConnection()
+|> Sql.connect
 |> Sql.query "SELECT uuid_generate_v4()"
 |> Sql.executeScalar
 |> function
-    | Uuid output -> printfn "Uuid generated: %A" output
+    | SqlValue.Uuid output -> printfn "Uuid generated: %A" output
     | _ -> failwith "Uuid could not be read failed"
 
 defaultConnection()
+|> Sql.connect
 |> Sql.query "CREATE TABLE IF NOT EXISTS data (version integer, date1 timestamptz, date2 timestamptz) "
 |> Sql.executeNonQuery
 |> printfn "Create Table data returned %A"
@@ -202,11 +230,13 @@ let delete = "DELETE from data"
 let insert = "INSERT INTO data (version, date1, date2) values (1, 'now', 'infinity')"
 
 defaultConnection()
+|> Sql.connect
 |> Sql.queryMany [ delete; insert ]
 |> Sql.executeMany
 |> printfn "Insert into Table data returned %A"
 
 defaultConnection()
+|> Sql.connect
 |> Sql.query "SELECT * FROM data"
 |> Sql.executeTableSafe
 |> function
@@ -214,14 +244,15 @@ defaultConnection()
     | Error ex -> printfn "Fails as expected with %A" ex.Message
 
 handleInfinityConnection()
+|> Sql.connect
 |> Sql.query "SELECT * FROM data"
 |> Sql.executeTableSafe
 |> function
     | Ok r -> printfn "Succeed as expected : %A vs %A" (r.Head.Item 2) System.DateTime.MaxValue
     | Error _ -> failwith "Should not fail"
 
-
 defaultConnection()
+|> Sql.connect
 |> Sql.query "DROP TABLE data"
 |> Sql.executeNonQuery
 |> printfn "Drop Table data returned %A"

--- a/src/Npgsql.FSharp.fsproj
+++ b/src/Npgsql.FSharp.fsproj
@@ -8,12 +8,13 @@
     <PackageIconUrl></PackageIconUrl>
     <PackageTags>fsharp;postgres;sql;ngpsql</PackageTags>
     <Authors>Zaid Ajaj</Authors>
-    <Version>0.8.0</Version>
+    <Version>1.0.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="Types.fs" />
     <Compile Include="Sql.fs" />
   </ItemGroup>
 

--- a/src/Types.fs
+++ b/src/Types.fs
@@ -1,0 +1,23 @@
+namespace Npgsql.FSharp
+
+open System 
+
+[<RequireQualifiedAccess>]
+type SqlValue =
+    | Short of int16
+    | Int of int
+    | Long of int64
+    | String of string
+    | Date of DateTime
+    | Bool of bool
+    | Number of double
+    | Decimal of decimal
+    | Bytea of byte[]
+    | HStore of Map<string, string>
+    | Uuid of Guid
+    | TimeWithTimeZone of DateTimeOffset
+    | Null
+
+type SqlRow = list<string * SqlValue>
+
+type SqlTable = list<SqlRow>


### PR DESCRIPTION
1- Upgrade the library with new combinators to easily with nullable rows:
```fs
Sql.readInt columnName row 
Sql.readString columnName row 
// etc.
```
Allows us to write functions such as
```fs
let getAllUsers() : User list =
    defaultConnection
    |> Sql.connect
    |> Sql.query "SELECT * FROM \"users\""
    |> Sql.executeTable 
    |> Sql.mapEachRow (fun row ->
        option {
            let! id = Sql.readInt "user_id" row 
            let! fname = Sql.readString "first_name" row 
            let! lname = Sql.readString "last_name" row
            return { Id = id; FirstName = fname; LastName = lname }
        }) 
```
2 - Fix `Null` value roundtrip because sending `null` is considored a null parameter instead of null value
3 - Add nullable active patterns
```fs
let value = SqlValue.Null 

match value with 
| NullDecimal (Some decimal) -> decimal
| NullDecimal None -> 0.0M
| otherwise -> (* you get the idea *)
```
# Breaking changes 0.8.0 -> 1.0.0
The `Sql` type is now renamed to `SqlValue` and requires qualified access. But added simple overloaded function `Sql.Value` to create instances of `SqlValue`. 

For example if you had this:
```fs
let userExists (name: string) : bool =
    defaultConnection
    |> Sql.connect
    |> Sql.func "user_exists"
    |> Sql.parameters ["username", String name]
    |> Sql.executeScalarSafe
    |> function 
           | Ok (Bool value) -> Ok value 
           | _ -> Error "Error while calling function 'user_exists'" 
```
then it becomes
```fs
let userExists (name: string) : bool =
    defaultConnection
    |> Sql.connect
    |> Sql.func "user_exists"
    |> Sql.parameters ["username", Sql.Value name] // or SqlValue.String name
    |> Sql.executeScalarSafe
    |> function 
           | Ok (SqlValue.Bool value) -> Ok value 
           | _ -> Error "Error while calling function 'user_exists'" 
```