### PR TITLE
Fix the one where readTableTaskCt reads a row without available reader

### DIFF
--- a/src/Sql.fs
+++ b/src/Sql.fs
@@ -345,8 +345,12 @@ module Sql =
             while !canRead do 
                 let! readerAvailable = reader.ReadAsync(cancellationToken)
                 canRead := readerAvailable
-                let! row = readRowTaskCt cancellationToken reader
-                rows.Add (List.ofArray row)
+                
+                if readerAvailable then 
+                    let! row = readRowTaskCt cancellationToken reader
+                    rows.Add (List.ofArray row)
+                else
+                    ()
             
             return List.ofArray (rows.ToArray())
         }


### PR DESCRIPTION
Don't fully understand this code but all of our project tests started failing after upgrading to latest Npgsql.FSharp version and this commit made them pass again.