### PR TITLE
Add ability to work with other values

### DIFF
--- a/src/Sql.fs
+++ b/src/Sql.fs
@@ -353,6 +353,14 @@ type RowReader(reader: NpgsqlDataReader) =
         match columnDict.TryGetValue(column) with
         | true, columnIndex -> reader.GetValue(columnIndex)
         | false, _ -> failToRead column "value"
+        
+    member this.valueOrNone(column: string) : obj option =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then None
+            else Some (reader.GetValue(columnIndex))
+        | false, _ -> failToRead column "value"
 
 [<RequireQualifiedAccess>]
 module Sql =

--- a/src/Types.fs
+++ b/src/Types.fs
@@ -1,5 +1,6 @@
 namespace Npgsql.FSharp
 
+
 open System
 
 [<RequireQualifiedAccess>]
@@ -25,3 +26,4 @@ type SqlValue =
     | Jsonb of string
     | StringArray of string array
     | IntArray of int array
+    | Value of obj


### PR DESCRIPTION
Hey. great work on the project :-) . I wanted to use this library, but couldn't work out how to handle INET field types. The underlying Npgsql reader has a GetValue method which seems to allow you to read such a value as an object that you can cast in accordance with [this](https://www.npgsql.org/doc/types/basic.html), but it didn't seem present in the library's API. This PR adds it, but doesn't unfortunately add any tests. I usually use Rider as my IDE, and I couldn't get it to work with paket, making tests a bit of a faff to do. Perhaps this can be used as a suggestion instead of being accepted as is?