### PR TITLE
removes trailing spaces from parameternames

### DIFF
--- a/src/Sql.fs
+++ b/src/Sql.fs
@@ -504,7 +504,7 @@ module Sql =
         for (paramName, value) in row do
             
             let normalizedParameterName =
-                let paramName = paramName.TrimEnd()
+                let paramName = paramName.Trim()
                 if not (paramName.StartsWith "@")
                 then sprintf "@%s" paramName
                 else paramName

--- a/src/Sql.fs
+++ b/src/Sql.fs
@@ -504,6 +504,7 @@ module Sql =
         for (paramName, value) in row do
             
             let normalizedParameterName =
+                let paramName = paramName.TrimEnd()
                 if not (paramName.StartsWith "@")
                 then sprintf "@%s" paramName
                 else paramName

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -209,10 +209,12 @@ let tests =
                     |> Sql.executeTransaction [
                         "INSERT INTO test (integers) VALUES (@integers)", [
                             [ ("@integers        ", Sql.intArray [| 1; 3; 7; |] ) ]
+                            [ ("    @integers"    , Sql.intArray [| 1; 3; 7; |] ) ]
+                            [ ("   integers      ", Sql.intArray [| 1; 3; 7; |] ) ]
                         ]
                     ]
 
-                Expect.equal result (Ok [1]) "paramaters can contain trailing spaces"
+                Expect.equal result (Ok [1; 1; 1;]) "paramaters can contain trailing spaces"
             }
 
             testAsync "Sql.executeRowAsync works" {

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -194,6 +194,27 @@ let tests =
                      | Error err -> raise err
             }
 
+            test "Paramater names can contain trailing spaces" {
+                use db = buildDatabase()
+                use connection = new NpgsqlConnection(db.ConnectionString)
+                connection.Open()
+                Sql.existingConnection connection
+                |> Sql.query "CREATE TABLE test (test_id serial primary key, integers int [])"
+                |> Sql.executeNonQuery
+                |> ignore
+
+
+                let result =
+                    Sql.existingConnection connection
+                    |> Sql.executeTransaction [
+                        "INSERT INTO test (integers) VALUES (@integers)", [
+                            [ ("@integers        ", Sql.intArray [| 1; 3; 7; |] ) ]
+                        ]
+                    ]
+
+                Expect.equal result (Ok [1]) "paramaters can contain trailing spaces"
+            }
+
             testAsync "Sql.executeRowAsync works" {
                 use db = buildDatabase()
                 db.ConnectionString


### PR DESCRIPTION
wanted to prevent people from losing their minds if they somehow accidentally add one more trailing spaces in a parameter name.

When you have trailing space(s) the current error is:
```
Error
  Npgsql.PostgresException (0x80004005): 42703: column "integers" does not exist
   at Npgsql.NpgsqlConnector.<>c__DisplayClass160_0.<<DoReadMessage>g__ReadMessageLong|0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Npgsql.NpgsqlConnector.<>c__DisplayClass160_0.<<DoReadMessage>g__ReadMessageLong|0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at Npgsql.NpgsqlDataReader.NextResult(Boolean async, Boolean isConsuming)
   at Npgsql.NpgsqlDataReader.NextResult()
   at Npgsql.NpgsqlCommand.ExecuteReaderAsync(CommandBehavior behavior, Boolean async, CancellationToken cancellationToken)
   at Npgsql.NpgsqlCommand.ExecuteNonQuery(Boolean async, CancellationToken cancellationToken)
   at Npgsql.NpgsqlCommand.ExecuteNonQuery()
   at Npgsql.FSharp.SqlModule.executeTransaction(FSharpList`1 queries, SqlProps props) in /Users/jonasdw/projects/forks/Npgsql.FSharp/src/Sql.fs:line 564
  Exception data:
    Severity: ERROR
    SqlState: 42703
    MessageText: column "integers" does not exist
    Hint: There is a column named "integers" in table "test", but it cannot be referenced from this part of the query.
    Position: 38
    File: parse_relation.c
    Line: 3294
    Routine: errorMissingColumn
```