### PR TITLE
Add support for reading/writing values as NpgsqlPoint

### DIFF
--- a/src/Types.fs
+++ b/src/Types.fs
@@ -2,10 +2,11 @@ namespace Npgsql.FSharp
 
 open System
 open Npgsql
+open NpgsqlTypes
 
 [<RequireQualifiedAccess>]
 type SqlValue =
-    | Parameter of NpgsqlParameter 
+    | Parameter of NpgsqlParameter
     | Null
     | TinyInt of int8
     | Short of int16
@@ -27,3 +28,4 @@ type SqlValue =
     | Jsonb of string
     | StringArray of string array
     | IntArray of int array
+    | Point of NpgsqlPoint


### PR DESCRIPTION
Hi 👋

This might be an unnecessary addition, but I was having trouble today trying to do this so it seemed like it might be a nice addition 🙂 

This adds support for adding `NpgsqlPoint` values as a parameter when building sql, and then reading them back from a query result. I tried to match the way things were done in the surrounding code, but let me know if I messed anything up and I can update this PR