### PR TITLE
Custom Exception Types

### DIFF
--- a/src/Sql.fs
+++ b/src/Sql.fs
@@ -392,6 +392,8 @@ module Sql =
         ExistingConnection : NpgsqlConnection option
     }
 
+    exception MissingQueryException of string
+
     let private defaultConString() : ConnectionStringBuilder = {
         Host = ""
         Database = ""
@@ -639,7 +641,8 @@ module Sql =
 
     let execute (read: RowReader -> 't) (props: SqlProps) : Result<'t list, exn> =
         try
-            if List.isEmpty props.SqlQuery then failwith "No query provided to execute. Please use Sql.query"
+            if List.isEmpty props.SqlQuery
+            then raise <| MissingQueryException "No query provided to execute. Please use Sql.query"
             let connection = getConnection props
             try
                 if not (connection.State.HasFlag ConnectionState.Open)
@@ -661,7 +664,8 @@ module Sql =
 
     let iter (perform: RowReader -> unit) (props: SqlProps) : Result<unit, exn> =
         try
-            if List.isEmpty props.SqlQuery then failwith "No query provided to execute. Please use Sql.query"
+            if List.isEmpty props.SqlQuery
+            then raise <| MissingQueryException "No query provided to execute. Please use Sql.query"
             let connection = getConnection props
             try
                 if not (connection.State.HasFlag ConnectionState.Open)
@@ -682,7 +686,8 @@ module Sql =
 
     let executeRow (read: RowReader -> 't) (props: SqlProps) : Result<'t, exn> =
         try
-            if List.isEmpty props.SqlQuery then failwith "No query provided to execute. Please use Sql.query"
+            if List.isEmpty props.SqlQuery
+            then raise <| MissingQueryException "No query provided to execute. Please use Sql.query"
             let connection = getConnection props
             try
                 if not (connection.State.HasFlag ConnectionState.Open)
@@ -708,7 +713,8 @@ module Sql =
                 let! token =  Async.CancellationToken
                 use mergedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token, props.CancellationToken)
                 let mergedToken = mergedTokenSource.Token
-                if List.isEmpty props.SqlQuery then failwith "No query provided to execute. Please use Sql.query"
+                if List.isEmpty props.SqlQuery
+                then raise <| MissingQueryException "No query provided to execute. Please use Sql.query"
                 let connection = getConnection props
                 try
                     if not (connection.State.HasFlag ConnectionState.Open)
@@ -735,7 +741,8 @@ module Sql =
                 let! token =  Async.CancellationToken
                 use mergedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token, props.CancellationToken)
                 let mergedToken = mergedTokenSource.Token
-                if List.isEmpty props.SqlQuery then failwith "No query provided to execute. Please use Sql.query"
+                if List.isEmpty props.SqlQuery
+                then raise <| MissingQueryException "No query provided to execute. Please use Sql.query"
                 let connection = getConnection props
                 try
                     if not (connection.State.HasFlag ConnectionState.Open)
@@ -761,7 +768,8 @@ module Sql =
                 let! token =  Async.CancellationToken
                 use mergedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token, props.CancellationToken)
                 let mergedToken = mergedTokenSource.Token
-                if List.isEmpty props.SqlQuery then failwith "No query provided to execute. Please use Sql.query"
+                if List.isEmpty props.SqlQuery
+                then raise <| MissingQueryException "No query provided to execute. Please use Sql.query"
                 let connection = getConnection props
                 try
                     if not (connection.State.HasFlag ConnectionState.Open)
@@ -785,7 +793,8 @@ module Sql =
     /// Executes the query and returns the number of rows affected
     let executeNonQuery (props: SqlProps) : Result<int, exn> =
         try
-            if List.isEmpty props.SqlQuery then failwith "No query provided to execute..."
+            if List.isEmpty props.SqlQuery
+            then raise <| MissingQueryException "No query provided to execute..."
             let connection = getConnection props
             try
                 if not (connection.State.HasFlag ConnectionState.Open)
@@ -807,7 +816,8 @@ module Sql =
                 let! token = Async.CancellationToken
                 use mergedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token, props.CancellationToken)
                 let mergedToken = mergedTokenSource.Token
-                if List.isEmpty props.SqlQuery then failwith "No query provided to execute. Please use Sql.query"
+                if List.isEmpty props.SqlQuery
+                then raise <| MissingQueryException "No query provided to execute. Please use Sql.query"
                 let connection = getConnection props
                 try
                     if not (connection.State.HasFlag ConnectionState.Open)

--- a/src/Sql.fs
+++ b/src/Sql.fs
@@ -393,6 +393,7 @@ module Sql =
     }
 
     exception MissingQueryException of string
+    exception NoResultsException of string
 
     let private defaultConString() : ConnectionStringBuilder = {
         Host = ""
@@ -700,7 +701,7 @@ module Sql =
                 let rowReader = RowReader(postgresReader)
                 if reader.Read()
                 then Ok (read rowReader)
-                else failwith "Expected at least one row to be returned from the result set. Instead it was empty"
+                else raise <| NoResultsException "Expected at least one row to be returned from the result set. Instead it was empty"
             finally
                 if props.ExistingConnection.IsNone
                 then connection.Dispose()
@@ -782,7 +783,7 @@ module Sql =
                     let rowReader = RowReader(postgresReader)
                     if reader.Read()
                     then return Ok (read rowReader)
-                    else return! failwith "Expected at least one row to be returned from the result set. Instead it was empty"
+                    else return! raise <| NoResultsException "Expected at least one row to be returned from the result set. Instead it was empty"
                 finally
                     if props.ExistingConnection.IsNone
                     then connection.Dispose()

--- a/tests/Tests.fs
+++ b/tests/Tests.fs
@@ -1079,5 +1079,39 @@ let tests =
 
     ]
 
+
+module Result =
+    let throwIfError<'t,'terr when 'terr :> exn> (x: Result<'t,'terr>) =
+        match x with
+        | Ok ok -> ok
+        | Error e -> raise e
+
+let dummyRead = ignore
+let testable f x =
+    f x |> Result.throwIfError |> ignore
+let asyncTestable f x =
+    f x |> Async.RunSynchronously |> Result.throwIfError |> ignore
+
+let missingQueryTests =
+        [ "Sql.execute", testable <| Sql.execute dummyRead
+          "Sql.iter", testable <| Sql.iter dummyRead
+          "Sql.executeRow", testable <| Sql.executeRow dummyRead
+          "Sql.executeNonQuery", testable Sql.executeNonQuery
+          "Sql.executeAsync", asyncTestable <| Sql.executeAsync dummyRead
+          "Sql.iterAsync", asyncTestable <| Sql.iterAsync dummyRead
+          "Sql.executeNonQueryAsync", asyncTestable Sql.executeNonQueryAsync ]
+        |> List.map
+            (fun (name, func) ->
+                test (sprintf "%s fails with MissingQueryException for missing query" name) {
+                    use db = buildDatabase()
+
+                    Expect.throwsT<Sql.MissingQueryException>
+                        (fun () -> db.ConnectionString |> Sql.connect |> func)
+                        "Check missing query fails with expected exception type"
+                })
+
+let errorTests =  testList "Custom Exception tests" missingQueryTests
+let allTests = testList "All tests" [ tests; errorTests ]
+
 [<EntryPoint>]
-let main args = runTestsWithArgs defaultConfig args tests
+let main args = runTestsWithArgs defaultConfig args allTests


### PR DESCRIPTION
This is an attempt at solving #70 

I added 3 different exception types and raised them in `Sql.fs` instead of any `failwith` calls so this shouldn't be raising `System.Exception`s anymore 🙂 

Writing individual tests was a bit tedious, so I added some helpers to the test file - happy to move/rename/change them if they're out of place though 🙂 