### PR TITLE
 * Extract SSL Mode from the URI

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "paket": {
+      "version": "5.257.0",
+      "commands": [
+        "paket"
+      ]
+    }
+  }
+}

--- a/src/PostgresUri.fs
+++ b/src/PostgresUri.fs
@@ -28,6 +28,17 @@ let private extractPort (uri: Uri) =
     | -1 -> Some (sprintf "Port=%d" 5432)
     | n -> Some (sprintf "Port=%d" n)
 
+let private extractSslMode (uri: Uri) =
+    let query = uri.Query
+    let query = if query.StartsWith "?" then query.Substring 1 else query
+
+    query.Split '&'
+    |> Seq.tryPick (fun part ->
+        match part.Split '=' with
+        | [| "sslmode"; x |] -> Some (sprintf "SslMode=%s" x)
+        | _ -> None
+    )
+
 type Uri with
     member uri.ToPostgresConnectionString() : string =
         let parts =  [
@@ -35,6 +46,7 @@ type Uri with
             extractUser uri
             extractDatabase uri
             extractPort uri
+            extractSslMode uri
         ]
 
         String.concat ";" (List.choose id parts)


### PR DESCRIPTION
This PR extends `ToPostgresConnectionString` so that it will extract `SslMode` from the query parameters. 

```fsharp
#load "./src/PostgresUri.fs"

open System

let uri = Uri "postgres://username:password123@mydb.aaaaaaaa.eu-west-2.rds.amazonaws.com:5432/postgres?sslmode=require"

let connectionString = uri.ToPostgresConnectionString ()

printfn "%A" connectionString

```