### PR TITLE
Adding support for ValueOption

### DIFF
--- a/src/Common.fs
+++ b/src/Common.fs
@@ -39,6 +39,9 @@ module internal Utils =
     let sqlMap (option: 'a option) (f: 'a -> SqlValue) : SqlValue =
         Option.defaultValue SqlValue.Null (Option.map f option)
 
+    let sqlValueMap (option: 'a voption) (f: 'a -> SqlValue) : SqlValue =
+        ValueOption.defaultValue SqlValue.Null (ValueOption.map f option)
+
 module Async =
     let map f comp =
         async {
@@ -53,32 +56,46 @@ exception UnknownColumnException of string
 type Sql() =
     static member int(value: int) = SqlValue.Int value
     static member intOrNone(value: int option) = Utils.sqlMap value Sql.int
+    static member intOrValueNone(value: int voption) = Utils.sqlValueMap value Sql.int
     static member string(value: string) = SqlValue.String (if isNull value then String.Empty else value)
     static member stringOrNone(value: string option) = Utils.sqlMap value Sql.string
+    static member stringOrValueNone(value: string voption) = Utils.sqlValueMap value Sql.string
     static member text(value: string) = SqlValue.String value
     static member textOrNone(value: string option) = Sql.stringOrNone value
+    static member textOrValueNone(value: string voption) = Sql.stringOrValueNone value
     static member jsonb(value: string) = SqlValue.Jsonb value
     static member jsonbOrNone(value: string option) = Utils.sqlMap value Sql.jsonb
+    static member jsonbOrValueNone(value: string voption) = Utils.sqlValueMap value Sql.jsonb
     static member bit(value: bool) = SqlValue.Bit value
     static member bitOrNone(value: bool option) = Utils.sqlMap value Sql.bit
+    static member bitOrValueNone(value: bool voption) = Utils.sqlValueMap value Sql.bit
     static member bool(value: bool) = SqlValue.Bool value
     static member boolOrNone(value: bool option) = Utils.sqlMap value Sql.bool
+    static member boolOrValueNone(value: bool voption) = Utils.sqlValueMap value Sql.bool
     static member double(value: double) = SqlValue.Number value
     static member doubleOrNone(value: double option) = Utils.sqlMap value Sql.double
+    static member doubleOrValueNone(value: double voption) = Utils.sqlValueMap value Sql.double
     static member decimal(value: decimal) = SqlValue.Decimal value
     static member decimalOrNone(value: decimal option) = Utils.sqlMap value Sql.decimal
+    static member decimalOrValueNone(value: decimal voption) = Utils.sqlValueMap value Sql.decimal
     static member money(value: decimal) = SqlValue.Money value
     static member moneyOrNone(value: decimal option) = Utils.sqlMap value Sql.money
+    static member moneyOrValueNone(value: decimal voption) = Utils.sqlValueMap value Sql.money
     static member int8(value: int8) = SqlValue.TinyInt value
     static member int8OrNone(value: int8 option) = Utils.sqlMap value Sql.int8
+    static member int8OrValueNone(value: int8 voption) = Utils.sqlValueMap value Sql.int8
     static member int16(value: int16) = SqlValue.Short value
     static member int16OrNone(value: int16 option) = Utils.sqlMap value Sql.int16
+    static member int16OrValueNone(value: int16 voption) = Utils.sqlValueMap value Sql.int16
     static member int64(value: int64) = SqlValue.Long value
     static member int64OrNone(value: int64 option) = Utils.sqlMap value Sql.int64
+    static member int64OrValueNone(value: int64 voption) = Utils.sqlValueMap value Sql.int64
     static member timestamp(value: DateTime) = SqlValue.Timestamp value
     static member timestampOrNone(value: DateTime option) = Utils.sqlMap value Sql.timestamp
+    static member timestampOrValueNone(value: DateTime voption) = Utils.sqlValueMap value Sql.timestamp
     static member timestamptz(value: DateTime) = SqlValue.TimestampWithTimeZone value
     static member timestamptzOrNone(value: DateTime option) = Utils.sqlMap value Sql.timestamptz
+    static member timestamptzOrValueNone(value: DateTime voption) = Utils.sqlValueMap value Sql.timestamptz
     static member timestamptz(value: DateTimeOffset) =
         let parameter = NpgsqlParameter()
         parameter.NpgsqlDbType <- NpgsqlDbType.TimestampTz
@@ -94,20 +111,36 @@ type Sql() =
             parameter.Value <- value
             SqlValue.Parameter parameter
 
+    static member timestamptzOrValueNone(value: DateTimeOffset voption) =
+        match value with
+        | ValueNone -> SqlValue.Null
+        | ValueSome value ->
+            let parameter = NpgsqlParameter()
+            parameter.NpgsqlDbType <- NpgsqlDbType.TimestampTz
+            parameter.Value <- value
+            SqlValue.Parameter parameter
+
     static member uuid(value: Guid) = SqlValue.Uuid value
     static member uuidOrNone(value: Guid option) = Utils.sqlMap value Sql.uuid
+    static member uuidOrValueNone(value: Guid voption) = Utils.sqlValueMap value Sql.uuid
     static member uuidArray(value: Guid []) = SqlValue.UuidArray value
     static member uuidArrayOrNone(value: Guid [] option) = Utils.sqlMap value Sql.uuidArray
+    static member uuidArrayOrValueNone(value: Guid [] voption) = Utils.sqlValueMap value Sql.uuidArray
     static member bytea(value: byte[]) = SqlValue.Bytea value
     static member byteaOrNone(value: byte[] option) = Utils.sqlMap value Sql.bytea
+    static member byteaOrValueNone(value: byte[] voption) = Utils.sqlValueMap value Sql.bytea
     static member stringArray(value: string[]) = SqlValue.StringArray value
     static member stringArrayOrNone(value: string[] option) = Utils.sqlMap value Sql.stringArray
+    static member stringArrayOrValueNone(value: string[] voption) = Utils.sqlValueMap value Sql.stringArray
     static member intArray(value: int[]) = SqlValue.IntArray value
     static member intArrayOrNone(value: int[] option) = Utils.sqlMap value Sql.intArray
+    static member intArrayOrValueNone(value: int[] voption) = Utils.sqlValueMap value Sql.intArray
     static member int16Array(value: int16[]) = SqlValue.ShortArray value
     static member int16ArrayOrNone(value: int16[] option) = Utils.sqlMap value Sql.int16Array
+    static member int16ArrayOrValueNone(value: int16[] voption) = Utils.sqlValueMap value Sql.int16Array
     static member int64Array(value: int64[]) = SqlValue.LongArray value
     static member int64ArrayOrNone(value: int64[] option) = Utils.sqlMap value Sql.int64Array
+    static member int64ArrayOrValueNone(value: int64[] voption) = Utils.sqlValueMap value Sql.int64Array
     static member dbnull = SqlValue.Null
     static member parameter(genericParameter: NpgsqlParameter) = SqlValue.Parameter genericParameter
     static member point(value: NpgsqlPoint) = SqlValue.Point value
@@ -151,6 +184,14 @@ type RowReader(reader: NpgsqlDataReader) =
             else Some (reader.GetInt32(columnIndex))
         | false, _ -> failToRead column "int"
 
+    member this.intOrValueNone(column: string) : int voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome (reader.GetInt32(columnIndex))
+        | false, _ -> failToRead column "int"
+
     /// Gets the value of the specified column as a 16-bit signed integer.
     ///
     /// Can be used to read columns of type `smallint` or `int16`
@@ -167,6 +208,14 @@ type RowReader(reader: NpgsqlDataReader) =
             else Some (reader.GetInt16(columnIndex))
         | false, _ -> failToRead column "int16"
 
+    member this.int16OrValueNone(column: string) : int16 voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome (reader.GetInt16(columnIndex))
+        | false, _ -> failToRead column "int16"
+
     member this.intArray(column: string) : int[] =
         match columnDict.TryGetValue(column) with
         | true, columnIndex -> reader.GetFieldValue<int[]>(columnIndex)
@@ -178,6 +227,14 @@ type RowReader(reader: NpgsqlDataReader) =
             if reader.IsDBNull(columnIndex)
             then None
             else Some (reader.GetFieldValue<int[]>(columnIndex))
+        | false, _ -> failToRead column "int[]"
+
+    member this.intArrayOrValueNone(column: string) : int[] voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome (reader.GetFieldValue<int[]>(columnIndex))
         | false, _ -> failToRead column "int[]"
 
     member this.int16Array(column: string) : int16[] =
@@ -193,6 +250,14 @@ type RowReader(reader: NpgsqlDataReader) =
             else Some (reader.GetFieldValue<int16[]>(columnIndex))
         | false, _ -> failToRead column "int16[]"
 
+    member this.int16ArrayOrValueNone(column: string) : int16[] voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome (reader.GetFieldValue<int16[]>(columnIndex))
+        | false, _ -> failToRead column "int16[]"
+
     member this.int64Array(column: string) : int64[] =
         match columnDict.TryGetValue(column) with
         | true, columnIndex -> reader.GetFieldValue<int64[]>(columnIndex)
@@ -204,6 +269,14 @@ type RowReader(reader: NpgsqlDataReader) =
             if reader.IsDBNull(columnIndex)
             then None
             else Some (reader.GetFieldValue<int64[]>(columnIndex))
+        | false, _ -> failToRead column "int64[]"
+
+    member this.int64ArrayOrValueNone(column: string) : int64[] voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome (reader.GetFieldValue<int64[]>(columnIndex))
         | false, _ -> failToRead column "int64[]"
 
     /// Reads the given column of type timestamptz as DateTimeOffset.
@@ -230,6 +303,15 @@ type RowReader(reader: NpgsqlDataReader) =
         | false, _ ->
             failToRead column "DateTimeOffset"
 
+    member this.datetimeOffsetOrValueNone(column: string) : DateTimeOffset voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome (reader.GetFieldValue<DateTimeOffset>(columnIndex).ToUniversalTime())
+        | false, _ ->
+            failToRead column "DateTimeOffset"
+
     member this.stringArray(column: string) : string[] =
         match columnDict.TryGetValue(column) with
         | true, columnIndex -> reader.GetFieldValue<string[]>(columnIndex)
@@ -243,6 +325,14 @@ type RowReader(reader: NpgsqlDataReader) =
             else Some (reader.GetFieldValue<string[]>(columnIndex))
         | false, _ -> failToRead column "string[]"
 
+    member this.stringArrayOrValueNone(column: string) : string[] voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome (reader.GetFieldValue<string[]>(columnIndex))
+        | false, _ -> failToRead column "string[]"
+
     member this.int64(column: string) : int64 =
         match columnDict.TryGetValue(column) with
         | true, columnIndex -> reader.GetInt64(columnIndex)
@@ -254,6 +344,14 @@ type RowReader(reader: NpgsqlDataReader) =
             if reader.IsDBNull(columnIndex)
             then None
             else Some (reader.GetInt64(columnIndex))
+        | false, _ -> failToRead column "int64"
+    
+    member this.int64OrValueNone(column: string) : int64 voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome (reader.GetInt64(columnIndex))
         | false, _ -> failToRead column "int64"
 
     member this.string(column: string) : string =
@@ -269,8 +367,17 @@ type RowReader(reader: NpgsqlDataReader) =
             else Some (reader.GetString(columnIndex))
         | false, _ -> failToRead column "string"
 
+    member this.stringOrValueNone(column: string) : string voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome (reader.GetString(columnIndex))
+        | false, _ -> failToRead column "string"
+
     member this.text(column: string) : string = this.string column
     member this.textOrNone(column: string) : string option = this.stringOrNone column
+    member this.textOrValueNone(column: string) : string voption = this.stringOrValueNone column
 
     member this.bool(column: string) : bool =
         match columnDict.TryGetValue(column) with
@@ -283,6 +390,14 @@ type RowReader(reader: NpgsqlDataReader) =
             if reader.IsDBNull(columnIndex)
             then None
             else Some (reader.GetFieldValue<bool>(columnIndex))
+        | false, _ -> failToRead column "bool"
+
+    member this.boolOrValueNone(column: string) : bool voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome (reader.GetFieldValue<bool>(columnIndex))
         | false, _ -> failToRead column "bool"
 
     member this.decimal(column: string) : decimal =
@@ -298,6 +413,14 @@ type RowReader(reader: NpgsqlDataReader) =
             else Some (reader.GetDecimal(columnIndex))
         | false, _ -> failToRead column "decimal"
 
+    member this.decimalOrValueNone(column: string) : decimal voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome (reader.GetDecimal(columnIndex))
+        | false, _ -> failToRead column "decimal"
+
     member this.double(column: string) : double =
         match columnDict.TryGetValue(column) with
         | true, columnIndex -> reader.GetDouble(columnIndex)
@@ -311,33 +434,57 @@ type RowReader(reader: NpgsqlDataReader) =
             else Some (reader.GetDouble(columnIndex))
         | false, _ -> failToRead column "double"
 
-    member this.timestamp(column: string) =
+    member this.doubleOrValueNone(column: string) : double voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome (reader.GetDouble(columnIndex))
+        | false, _ -> failToRead column "double"
+
+    member this.timestamp(column: string) : NpgsqlDateTime =
         match columnDict.TryGetValue(column) with
         | true, columnIndex -> reader.GetTimeStamp(columnIndex)
         | false, _ -> failToRead column "timestamp"
 
-    member this.timestampOrNone(column: string) =
+    member this.timestampOrNone(column: string) : NpgsqlDateTime option =
         match columnDict.TryGetValue(column) with
         | true, columnIndex ->
             if reader.IsDBNull(columnIndex)
             then None
             else Some (reader.GetTimeStamp(columnIndex))
+        | false, _ -> failToRead column "timestamp"
+
+    member this.timestampOrValueNone(column: string) : NpgsqlDateTime voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome (reader.GetTimeStamp(columnIndex))
         | false, _ -> failToRead column "timestamp"
 
     member this.NpgsqlReader = reader
 
-    member this.timestamptz(column: string) =
+    member this.timestamptz(column: string) : NpgsqlDateTime =
         match columnDict.TryGetValue(column) with
         | true, columnIndex -> reader.GetTimeStamp(columnIndex)
-        | false, _ -> failToRead column "timestamp"
+        | false, _ -> failToRead column "timestampz"
 
-    member this.timestamptzOrNone(column: string) =
+    member this.timestamptzOrNone(column: string) : NpgsqlDateTime option =
         match columnDict.TryGetValue(column) with
         | true, columnIndex ->
             if reader.IsDBNull(columnIndex)
             then None
             else Some (reader.GetTimeStamp(columnIndex))
-        | false, _ -> failToRead column "timestamp"
+        | false, _ -> failToRead column "timestampz"
+
+    member this.timestamptzOrValueNone(column: string) : NpgsqlDateTime voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome (reader.GetTimeStamp(columnIndex))
+        | false, _ -> failToRead column "timestampz"
 
     /// Gets the value of the specified column as a globally-unique identifier (GUID).
     member this.uuid(column: string) : Guid =
@@ -353,6 +500,14 @@ type RowReader(reader: NpgsqlDataReader) =
             else Some(reader.GetGuid(columnIndex))
         | false, _ -> failToRead column "guid"
 
+    member this.uuidOrValueNone(column: string) : Guid voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome(reader.GetGuid(columnIndex))
+        | false, _ -> failToRead column "guid"
+
     /// Gets the value of the specified column as a globally-unique identifier (GUID).
     member this.uuidArray(column: string) : Guid [] =
         match columnDict.TryGetValue(column) with
@@ -365,6 +520,14 @@ type RowReader(reader: NpgsqlDataReader) =
             if reader.IsDBNull(columnIndex)
             then None
             else Some(reader.GetFieldValue<Guid []>(columnIndex))
+        | false, _ -> failToRead column "guid[]"
+
+    member this.uuidArrayOrValueNone(column: string) : Guid [] voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome(reader.GetFieldValue<Guid []>(columnIndex))
         | false, _ -> failToRead column "guid[]"
 
     /// Gets the value of the specified column as an `NpgsqlTypes.NpgsqlDate`, Npgsql's provider-specific type for dates.
@@ -390,6 +553,14 @@ type RowReader(reader: NpgsqlDataReader) =
             else Some (reader.GetDate(columnIndex))
         | false, _ -> failToRead column "date"
 
+    member this.dateOrValueNone(column: string) : NpgsqlDate voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull (columnIndex)
+            then ValueNone
+            else ValueSome (reader.GetDate(columnIndex))
+        | false, _ -> failToRead column "date"
+
     /// Gets the value of the specified column as a System.DateTime object.
     member this.dateTime(column: string) : DateTime =
         match columnDict.TryGetValue(column) with
@@ -403,6 +574,14 @@ type RowReader(reader: NpgsqlDataReader) =
             if reader.IsDBNull(columnIndex)
             then None
             else Some (reader.GetDateTime(columnIndex))
+        | false, _ -> failToRead column "datetime"
+
+    member this.dateTimeOrValueNone(column: string) : DateTime voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome (reader.GetDateTime(columnIndex))
         | false, _ -> failToRead column "datetime"
 
     /// Gets the value of the specified column as an `NpgsqlTypes.NpgsqlTimeSpan`, Npgsql's provider-specific type for time spans.
@@ -428,6 +607,14 @@ type RowReader(reader: NpgsqlDataReader) =
             else Some (reader.GetFieldValue<byte[]>(columnIndex))
         | false, _ -> failToRead column "byte[]"
 
+    member this.byteaOrValueNone(column: string) : byte[] voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome (reader.GetFieldValue<byte[]>(columnIndex))
+        | false, _ -> failToRead column "byte[]"
+
     /// Gets the value of the specified column as a `System.Single` object.
     member this.float(column: string) : float32 =
         match columnDict.TryGetValue(column) with
@@ -443,6 +630,14 @@ type RowReader(reader: NpgsqlDataReader) =
             else Some (reader.GetFloat(columnIndex))
         | false, _ -> failToRead column "float"
 
+    member this.floatOrValueNone(column: string) : float32 voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome (reader.GetFloat(columnIndex))
+        | false, _ -> failToRead column "float"
+
     /// Gets the value of the specified column as an `NpgsqlTypes.NpgsqlPoint`
     member this.point(column: string) : NpgsqlPoint =
         match columnDict.TryGetValue(column) with
@@ -456,4 +651,12 @@ type RowReader(reader: NpgsqlDataReader) =
             if reader.IsDBNull(columnIndex)
             then None
             else Some (reader.GetFieldValue<NpgsqlPoint>(columnIndex))
+        | false, _ -> failToRead column "npgsqlpoint"
+
+    member this.pointOrValueNone(column: string) : NpgsqlPoint voption =
+        match columnDict.TryGetValue(column) with
+        | true, columnIndex ->
+            if reader.IsDBNull(columnIndex)
+            then ValueNone
+            else ValueSome (reader.GetFieldValue<NpgsqlPoint>(columnIndex))
         | false, _ -> failToRead column "npgsqlpoint"

--- a/src/Npgsql.FSharp.fs
+++ b/src/Npgsql.FSharp.fs
@@ -511,7 +511,7 @@ module Sql =
             | error -> Error error
 
     /// Executes the query as asynchronously and returns the number of rows affected
-    let executeNonQueryAsync  (props: SqlProps) =
+    let executeNonQueryAsync (props: SqlProps) =
         async {
             try
                 let! token = Async.CancellationToken

--- a/tests/NpgsqlFSharpTasksTests.fs
+++ b/tests/NpgsqlFSharpTasksTests.fs
@@ -59,7 +59,11 @@ let buildDatabaseConnection handleInfinity : ThrowawayDatabase =
     let databasePassword =
         let runningTravis = Environment.GetEnvironmentVariable "TESTING_IN_TRAVISCI"
         if isNull runningTravis || String.IsNullOrWhiteSpace runningTravis
-        then "postgres" // for local tests
+        then
+            let localPwd = Environment.GetEnvironmentVariable "Npgsql.Fsharp.DbPwd"
+            if String.IsNullOrWhiteSpace localPwd
+            then "postgres" // for local tests
+            else localPwd
         else "" // for Travis CI
 
     let connection =
@@ -1149,6 +1153,145 @@ let tests =
 
                 Expect.equal expected table "All rows from `point_test` table"
             }
+
+            test "Sql returned types" {
+                //Int
+                let data = 1
+                let value = Sql.int data
+                Expect.equal (SqlValue.Int data) value "Unexpected value Sql.int"
+
+                let value = Sql.intOrNone (Some data)
+                Expect.equal (SqlValue.Int data) value "Unexpected value Sql.intOrNone (Some)"
+
+                let value = Sql.intOrNone None
+                Expect.equal SqlValue.Null value "Unexpected value Sql.intOrNone (None)"
+
+                let value = Sql.intOrValueNone (ValueSome data)
+                Expect.equal (SqlValue.Int data) value "Unexpected value Sql.intOrValueNone (ValueSome)"
+
+                let value = Sql.intOrValueNone ValueNone
+                Expect.equal SqlValue.Null value "Unexpected value Sql.intOrValueNone (ValueNone)"
+
+                //String
+                let data = "str"
+                let value = Sql.string data
+                Expect.equal (SqlValue.String data) value "Unexpected value Sql.string"
+
+                let value = Sql.stringOrNone (Some data)
+                Expect.equal (SqlValue.String data) value "Unexpected value Sql.stringOrNone (Some)"
+
+                let value = Sql.stringOrNone None
+                Expect.equal SqlValue.Null value "Unexpected value Sql.stringOrNone (None)"
+
+                let value = Sql.stringOrValueNone (ValueSome data)
+                Expect.equal (SqlValue.String data) value "Unexpected value Sql.stringOrValueNone (ValueSome)"
+
+                let value = Sql.stringOrValueNone ValueNone
+                Expect.equal SqlValue.Null value "Unexpected value Sql.stringOrValueNone (ValueNone)"
+
+                //Text
+                let data = "text"
+                let value = Sql.text data
+                Expect.equal (SqlValue.String data) value "Unexpected value Sql.text"
+
+                let value = Sql.textOrNone (Some data)
+                Expect.equal (SqlValue.String data) value "Unexpected value Sql.textOrNone (Some)"
+
+                let value = Sql.textOrNone None
+                Expect.equal SqlValue.Null value "Unexpected value Sql.textOrNone (None)"
+
+                let value = Sql.textOrValueNone (ValueSome data)
+                Expect.equal (SqlValue.String data) value "Unexpected value Sql.textOrValueNone (ValueSome)"
+
+                let value = Sql.textOrValueNone ValueNone
+                Expect.equal SqlValue.Null value "Unexpected value Sql.textOrValueNone (ValueNone)"
+
+                //bit
+                let data = true
+                let value = Sql.bit data
+                Expect.equal (SqlValue.Bit data) value "Unexpected value Sql.bit"
+
+                let value = Sql.bitOrNone (Some data)
+                Expect.equal (SqlValue.Bit data) value "Unexpected value Sql.bitOrNone (Some)"
+
+                let value = Sql.bitOrNone None
+                Expect.equal SqlValue.Null value "Unexpected value Sql.bitOrNone (None)"
+
+                let value = Sql.bitOrValueNone (ValueSome data)
+                Expect.equal (SqlValue.Bit data) value "Unexpected value Sql.bitOrValueNone (ValueSome)"
+
+                let value = Sql.bitOrValueNone ValueNone
+                Expect.equal SqlValue.Null value "Unexpected value Sql.bitOrValueNone (ValueNone)"
+
+                //bool
+                let data = true
+                let value = Sql.bool data
+                Expect.equal (SqlValue.Bool data) value "Unexpected value Sql.bool"
+
+                let value = Sql.boolOrNone (Some data)
+                Expect.equal (SqlValue.Bool data) value "Unexpected value Sql.boolOrNone (Some)"
+
+                let value = Sql.boolOrNone None
+                Expect.equal SqlValue.Null value "Unexpected value Sql.boolOrNone (None)"
+
+                let value = Sql.boolOrValueNone (ValueSome data)
+                Expect.equal (SqlValue.Bool data) value "Unexpected value Sql.boolOrValueNone (ValueSome)"
+
+                let value = Sql.boolOrValueNone ValueNone
+                Expect.equal SqlValue.Null value "Unexpected value Sql.boolOrValueNone (ValueNone)"
+
+                //double
+                let data = 7.
+                let value = Sql.double data
+                Expect.equal (SqlValue.Number data) value "Unexpected value Sql.double"
+
+                let value = Sql.doubleOrNone (Some data)
+                Expect.equal (SqlValue.Number data) value "Unexpected value Sql.doubleOrNone (Some)"
+
+                let value = Sql.doubleOrNone None
+                Expect.equal SqlValue.Null value "Unexpected value Sql.doubleOrNone (None)"
+
+                let value = Sql.doubleOrValueNone (ValueSome data)
+                Expect.equal (SqlValue.Number data) value "Unexpected value Sql.doubleOrValueNone (ValueSome)"
+
+                let value = Sql.doubleOrValueNone ValueNone
+                Expect.equal SqlValue.Null value "Unexpected value Sql.doubleOrValueNone (ValueNone)"
+                
+                //decimal
+                let data = 9M
+                let value = Sql.decimal data
+                Expect.equal (SqlValue.Decimal data) value "Unexpected value Sql.decimal"
+
+                let value = Sql.decimalOrNone (Some data)
+                Expect.equal (SqlValue.Decimal data) value "Unexpected value Sql.decimalOrNone (Some)"
+
+                let value = Sql.decimalOrNone None
+                Expect.equal SqlValue.Null value "Unexpected value Sql.decimalOrNone (None)"
+
+                let value = Sql.decimalOrValueNone (ValueSome data)
+                Expect.equal (SqlValue.Decimal data) value "Unexpected value Sql.decimalOrValueNone (ValueSome)"
+
+                let value = Sql.decimalOrValueNone ValueNone
+                Expect.equal SqlValue.Null value "Unexpected value Sql.decimalOrValueNone (ValueNone)"
+
+                //timestamp
+                let data = DateTime(2021, 02, 28)
+                let value = Sql.timestamp data
+                Expect.equal (SqlValue.Timestamp data) value "Unexpected value Sql.timestamp"
+
+                let value = Sql.timestampOrNone (Some data)
+                Expect.equal (SqlValue.Timestamp data) value "Unexpected value Sql.timestampOrNone (Some)"
+
+                let value = Sql.timestampOrNone None
+                Expect.equal SqlValue.Null value "Unexpected value Sql.timestampOrNone (None)"
+
+                let value = Sql.timestampOrValueNone (ValueSome data)
+                Expect.equal (SqlValue.Timestamp data) value "Unexpected value Sql.timestampOrValueNone (ValueSome)"
+
+                let value = Sql.timestampOrValueNone ValueNone
+                Expect.equal SqlValue.Null value "Unexpected value Sql.timestampOrValueNone (ValueNone)"
+            }
+
         ] |> testSequenced
 
     ]

--- a/tests/NpgsqlFSharpTessts.fs
+++ b/tests/NpgsqlFSharpTessts.fs
@@ -59,7 +59,11 @@ let buildDatabaseConnection handleInfinity : ThrowawayDatabase =
     let databasePassword =
         let runningTravis = Environment.GetEnvironmentVariable "TESTING_IN_TRAVISCI"
         if isNull runningTravis || String.IsNullOrWhiteSpace runningTravis
-        then "postgres" // for local tests
+        then
+            let localPwd = Environment.GetEnvironmentVariable "Npgsql.Fsharp.DbPwd"
+            if String.IsNullOrWhiteSpace localPwd
+            then "postgres" // for local tests
+            else localPwd
         else "" // for Travis CI
 
     let connection =


### PR DESCRIPTION
Added support for ValueOption in 
 - type Sql()
 - type RowReader(reader: NpgsqlDataReader)
 - Adjusted tests to allow define a db password as environment variable
 - Added really simple test to validate type returned by Sql type
