### PR TITLE
Added support for the interval type.

### DIFF
--- a/src/Common.fs
+++ b/src/Common.fs
@@ -35,6 +35,7 @@ type SqlValue =
     | ShortArray of int16 array
     | LongArray of int64 array
     | Point of NpgsqlPoint
+    | Interval of TimeSpan
 
 module internal Utils =
     let sqlMap (option: 'a option) (f: 'a -> SqlValue) : SqlValue =
@@ -141,7 +142,9 @@ type Sql() =
     static member dbnull = SqlValue.Null
     static member parameter(genericParameter: NpgsqlParameter) = SqlValue.Parameter genericParameter
     static member point(value: NpgsqlPoint) = SqlValue.Point value
-
+    static member interval(value: TimeSpan) = SqlValue.Interval value
+    static member intervalOrNone(value: TimeSpan option) = Utils.sqlMap value Sql.interval
+    static member intervalOrValueNone(value: TimeSpan voption) = Utils.sqlValueMap value Sql.interval
 
 type RowReader(reader: NpgsqlDataReader) =
     let columnDict = Dictionary<string, int>()
@@ -417,4 +420,13 @@ type RowReader(reader: NpgsqlDataReader) =
         this.fieldValueOrNone(column)
 
     member this.pointOrValueNone(column: string) : NpgsqlPoint voption =
+        this.fieldValueOrValueNone(column)
+
+    member this.interval(column: string) : TimeSpan =
+        this.fieldValue(column)
+
+    member this.intervalOrNone(column: string) : TimeSpan option =
+        this.fieldValueOrNone(column)
+
+    member this.intervalOrValueNone(column: string) : TimeSpan voption =
         this.fieldValueOrValueNone(column)

--- a/src/Npgsql.FSharp.fs
+++ b/src/Npgsql.FSharp.fs
@@ -238,6 +238,7 @@ module Sql =
                 x.ParameterName <- normalizedParameterName
                 ignore (cmd.Parameters.Add(x))
             | SqlValue.Point x -> add x NpgsqlDbType.Point
+            | SqlValue.Interval x -> add x NpgsqlDbType.Interval
 
     let private populateCmd (cmd: NpgsqlCommand) (props: SqlProps) =
         if props.IsFunction then cmd.CommandType <- CommandType.StoredProcedure

--- a/tests/NpgsqlFSharpTests.fs
+++ b/tests/NpgsqlFSharpTests.fs
@@ -628,6 +628,17 @@ let tests =
                 |> fun output -> Expect.equal id output.[0] "Check uuid read from database is the same sent"
             }
 
+            test "Interval roundtrip" {
+                use db = buildDatabase()
+                let oneHourInterval : TimeSpan = TimeSpan.FromHours 1.0
+                db.ConnectionString
+                |> Sql.connect
+                |> Sql.query "SELECT @interval_input as output"
+                |> Sql.parameters [ "interval_input", Sql.interval oneHourInterval ]
+                |> Sql.execute (fun read -> read.interval "output")
+                |> fun output -> Expect.equal oneHourInterval output.[0] "Check interval read from database is the same sent"
+            }
+
             test "Money roundtrip with @ sign" {
                 use db = buildDatabase()
                 db.ConnectionString


### PR DESCRIPTION
Added support for the interval type.

It should be noted from [npgsql.org/doc/types/basic.html](https://www.npgsql.org/doc/types/basic.html) intervals with
month and year components set, cannot be read as a TimeSpan. 

I don't know if we want any custom validation/error handling for this, or just leave it as a runtime error as it currently is.

This should also address the issue #109 