### PR TITLE
Add DateOnly support

### DIFF
--- a/src/Common.fs
+++ b/src/Common.fs
@@ -411,13 +411,13 @@ type RowReader(reader: NpgsqlDataReader) =
         this.fieldValueOrValueNone(column)
 
     /// Gets the value of the specified column as a System.DateOnly object.
-    member this.date(column: string) : DateOnly =
+    member this.dateOnly(column: string) : DateOnly =
         this.fieldValue(column)
 
-    member this.dateOrNone(column: string) : DateOnly option =
+    member this.dateOnlyOrNone(column: string) : DateOnly option =
         this.fieldValueOrNone(column)
 
-    member this.dateOrValueNone(column: string) : DateOnly voption =
+    member this.dateOnlyOrValueNone(column: string) : DateOnly voption =
         this.fieldValueOrValueNone(column)
 
     /// Gets the value of the specified column as a System.DateTime object.

--- a/src/Common.fs
+++ b/src/Common.fs
@@ -15,7 +15,7 @@ type SqlValue =
     | Int of int
     | Long of int64
     | String of string
-    | Date of DateTime
+    | Date of Choice<DateTime, DateOnly>
     | Bit of bool
     | Bool of bool
     | Number of double
@@ -90,6 +90,12 @@ type Sql() =
     static member int64(value: int64) = SqlValue.Long value
     static member int64OrNone(value: int64 option) = Utils.sqlMap value Sql.int64
     static member int64OrValueNone(value: int64 voption) = Utils.sqlValueMap value Sql.int64
+    static member date(value: DateTime) = SqlValue.Date (Choice1Of2 value)
+    static member dateOrNone(value: DateTime option) = Utils.sqlMap value Sql.date
+    static member dateOrValueNone(value: DateTime voption) = Utils.sqlValueMap value Sql.date
+    static member date(value: DateOnly) = SqlValue.Date (Choice2Of2 value)
+    static member dateOrNone(value: DateOnly option) = Utils.sqlMap value Sql.date
+    static member dateOrValueNone(value: DateOnly voption) = Utils.sqlValueMap value Sql.date
     static member timestamp(value: DateTime) = SqlValue.Timestamp value
     static member timestampOrNone(value: DateTime option) = Utils.sqlMap value Sql.timestamp
     static member timestampOrValueNone(value: DateTime voption) = Utils.sqlValueMap value Sql.timestamp
@@ -402,6 +408,16 @@ type RowReader(reader: NpgsqlDataReader) =
         this.fieldValue(column)
 
     member this.uuidArrayOrValueNone(column: string) : Guid [] voption =
+        this.fieldValueOrValueNone(column)
+
+    /// Gets the value of the specified column as a System.DateOnly object.
+    member this.date(column: string) : DateOnly =
+        this.fieldValue(column)
+
+    member this.dateOrNone(column: string) : DateOnly option =
+        this.fieldValueOrNone(column)
+
+    member this.dateOrValueNone(column: string) : DateOnly voption =
         this.fieldValueOrValueNone(column)
 
     /// Gets the value of the specified column as a System.DateTime object.

--- a/src/Npgsql.FSharp.fs
+++ b/src/Npgsql.FSharp.fs
@@ -214,7 +214,8 @@ module Sql =
             | SqlValue.Uuid uuid -> add uuid NpgsqlDbType.Uuid
             | SqlValue.UuidArray uuidArray -> add uuidArray (NpgsqlDbType.Array ||| NpgsqlDbType.Uuid)
             | SqlValue.Short number -> add number NpgsqlDbType.Smallint
-            | SqlValue.Date date -> add date NpgsqlDbType.Date
+            | SqlValue.Date (Choice1Of2 dateTime) -> add dateTime NpgsqlDbType.Date
+            | SqlValue.Date (Choice2Of2 dateOnly) -> add dateOnly NpgsqlDbType.Date
             | SqlValue.Timestamp timestamp -> add timestamp NpgsqlDbType.Timestamp
             | SqlValue.TimestampWithTimeZone timestampTz -> add timestampTz NpgsqlDbType.TimestampTz
             | SqlValue.Number number -> add number NpgsqlDbType.Double

--- a/tests/NpgsqlFSharpTests.fs
+++ b/tests/NpgsqlFSharpTests.fs
@@ -672,6 +672,58 @@ let tests =
                 |> fun timestamp -> Expect.equal (timestamp.ToUnixTimeSeconds()) (value.ToUnixTimeSeconds()) "The values are the same"
             }
 
+            test "DateTime as date roundtrip" {
+                use db = buildDatabase()
+
+                let value = DateTime.Now
+
+                db.ConnectionString
+                |> Sql.connect
+                |> Sql.query "SELECT @date::date as value"
+                |> Sql.parameters [ "@date", Sql.date value ]
+                |> Sql.executeRow (fun read -> read.date "value")
+                |> fun date -> Expect.equal date (DateOnly.FromDateTime value) "The values are the same"
+            }
+
+            test "DateOnly as date roundtrip" {
+                use db = buildDatabase()
+
+                let value = DateOnly.FromDateTime DateTime.Now
+
+                db.ConnectionString
+                |> Sql.connect
+                |> Sql.query "SELECT @date::date as value"
+                |> Sql.parameters [ "@date", Sql.date value ]
+                |> Sql.executeRow (fun read -> read.date "value")
+                |> fun date -> Expect.equal date value "The values are the same"
+            }
+
+            test "None DateOnly as date roundtrip" {
+                use db = buildDatabase()
+
+                let value: DateOnly option = None
+
+                db.ConnectionString
+                |> Sql.connect
+                |> Sql.query "SELECT @date::date as value"
+                |> Sql.parameters [ "@date", Sql.dateOrNone value ]
+                |> Sql.executeRow (fun read -> read.dateOrNone "value")
+                |> fun date -> Expect.equal date value "The values are the same"
+            }
+
+            test "ValueSome DateOnly option as date roundtrip" {
+                use db = buildDatabase()
+
+                let value = DateOnly.FromDateTime DateTime.Now |> ValueSome
+
+                db.ConnectionString
+                |> Sql.connect
+                |> Sql.query "SELECT @date::date as value"
+                |> Sql.parameters [ "@date", Sql.dateOrValueNone value ]
+                |> Sql.executeRow (fun read -> read.dateOrValueNone "value")
+                |> fun date -> Expect.equal date value "The values are the same"
+            }
+
             test "uuid_generate_v4()" {
                 use db = buildDatabase()
                 db.ConnectionString

--- a/tests/NpgsqlFSharpTests.fs
+++ b/tests/NpgsqlFSharpTests.fs
@@ -675,14 +675,14 @@ let tests =
             test "DateTime as date roundtrip" {
                 use db = buildDatabase()
 
-                let value = DateTime.Now
+                let value = DateTime.Today
 
                 db.ConnectionString
                 |> Sql.connect
                 |> Sql.query "SELECT @date::date as value"
                 |> Sql.parameters [ "@date", Sql.date value ]
-                |> Sql.executeRow (fun read -> read.date "value")
-                |> fun date -> Expect.equal date (DateOnly.FromDateTime value) "The values are the same"
+                |> Sql.executeRow (fun read -> read.dateTime "value")
+                |> fun dateTime -> Expect.equal dateTime value "The values are the same"
             }
 
             test "DateOnly as date roundtrip" {
@@ -694,8 +694,8 @@ let tests =
                 |> Sql.connect
                 |> Sql.query "SELECT @date::date as value"
                 |> Sql.parameters [ "@date", Sql.date value ]
-                |> Sql.executeRow (fun read -> read.date "value")
-                |> fun date -> Expect.equal date value "The values are the same"
+                |> Sql.executeRow (fun read -> read.dateTime "value")
+                |> fun dateTime -> Expect.equal (DateOnly.FromDateTime dateTime) value "The values are the same"
             }
 
             test "None DateOnly as date roundtrip" {
@@ -707,7 +707,7 @@ let tests =
                 |> Sql.connect
                 |> Sql.query "SELECT @date::date as value"
                 |> Sql.parameters [ "@date", Sql.dateOrNone value ]
-                |> Sql.executeRow (fun read -> read.dateOrNone "value")
+                |> Sql.executeRow (fun read -> read.dateOnlyOrNone "value")
                 |> fun date -> Expect.equal date value "The values are the same"
             }
 
@@ -720,7 +720,7 @@ let tests =
                 |> Sql.connect
                 |> Sql.query "SELECT @date::date as value"
                 |> Sql.parameters [ "@date", Sql.dateOrValueNone value ]
-                |> Sql.executeRow (fun read -> read.dateOrValueNone "value")
+                |> Sql.executeRow (fun read -> read.dateOnlyOrValueNone "value")
                 |> fun date -> Expect.equal date value "The values are the same"
             }
 


### PR DESCRIPTION
- `Sql.date*` methods for inputting `date` parameters. Accepts both `DateTime` and `DateOnly`.
- `RowReader.dateOnly*` for reading `date` columns as `DateOnly`.