### PR TITLE
Handle `SqlValue.Date` correctly when populating rows in batch

### DIFF
--- a/src/Npgsql.FSharp.fs
+++ b/src/Npgsql.FSharp.fs
@@ -262,7 +262,8 @@ module Sql =
             | SqlValue.Uuid uuid -> add uuid NpgsqlDbType.Uuid
             | SqlValue.UuidArray uuidArray -> add uuidArray (NpgsqlDbType.Array ||| NpgsqlDbType.Uuid)
             | SqlValue.Short number -> add number NpgsqlDbType.Smallint
-            | SqlValue.Date date -> add date NpgsqlDbType.Date
+            | SqlValue.Date (Choice1Of2 dateTime) -> add dateTime NpgsqlDbType.Date
+            | SqlValue.Date (Choice2Of2 dateOnly) -> add dateOnly NpgsqlDbType.Date
             | SqlValue.Timestamp timestamp -> add timestamp NpgsqlDbType.Timestamp
             | SqlValue.TimestampWithTimeZone timestampTz -> add timestampTz NpgsqlDbType.TimestampTz
             | SqlValue.Number number -> add number NpgsqlDbType.Double

--- a/tests/NpgsqlFSharpTests.fs
+++ b/tests/NpgsqlFSharpTests.fs
@@ -288,6 +288,44 @@ let tests =
                 |> fun count -> Expect.equal count 0 "Count is zero"
             }
 
+            test "Sql.executeTransaction works with DateTime" {
+                use db = buildDatabase()
+                Sql.connect db.ConnectionString
+                |> Sql.query "CREATE TABLE users (user_id serial primary key, birthdate date)"
+                |> Sql.executeNonQuery
+                |> ignore
+
+                let date = DateTime.Now
+
+                Sql.connect db.ConnectionString
+                |> Sql.executeTransaction [
+                    "INSERT INTO users (birthdate) VALUES (@birthdate)", [
+                        [ ("@birthdate", Sql.dateOrNone (Some date)) ]
+                        [ ("@birthdate", Sql.dateOrNone Option<DateTime>.None) ]
+                    ]
+                ]
+                |> ignore
+            }
+
+            test "Sql.executeTransaction works with DateOnly" {
+                use db = buildDatabase()
+                Sql.connect db.ConnectionString
+                |> Sql.query "CREATE TABLE users (user_id serial primary key, birthdate date)"
+                |> Sql.executeNonQuery
+                |> ignore
+
+                let date = DateOnly.FromDateTime DateTime.Now
+
+                Sql.connect db.ConnectionString
+                |> Sql.executeTransaction [
+                    "INSERT INTO users (birthdate) VALUES (@birthdate)", [
+                        [ ("@birthdate", Sql.dateOrNone (Some date)) ]
+                        [ ("@birthdate", Sql.dateOrNone Option<DateOnly>.None) ]
+                    ]
+                ]
+                |> ignore
+            }
+
             test "Parameter names can contain trailing spaces" {
                 use db = buildDatabase()
                 use connection = new NpgsqlConnection(db.ConnectionString)


### PR DESCRIPTION
Hi! :wave: The other day, my colleague @vKito encountered an issue when using `DateOnly` types. After some digging, we found that the issue only happens when they are used in transactions, because the `populateBatchRow` function was not updated in #126. 

I added a test in a separate commit to verify that my code change did actually fix the problem. I was not sure where best to add these new tests.