### PR TITLE
Use PrepareAsync for asynchronous calls

### DIFF
--- a/src/Npgsql.FSharp.fs
+++ b/src/Npgsql.FSharp.fs
@@ -458,7 +458,8 @@ module Sql =
                 then do! connection.OpenAsync(props.CancellationToken)
                 use command = makeCommand props connection
                 do populateCmd command props
-                if props.NeedPrepare then command.Prepare()
+                if props.NeedPrepare then
+                    do! command.PrepareAsync(props.CancellationToken)
                 use! reader = command.ExecuteReaderAsync props.CancellationToken
                 let postgresReader = unbox<NpgsqlDataReader> reader
                 let rowReader = RowReader(postgresReader)
@@ -482,7 +483,8 @@ module Sql =
                 then do! connection.OpenAsync(props.CancellationToken)
                 use command = makeCommand props connection
                 do populateCmd command props
-                if props.NeedPrepare then command.Prepare()
+                if props.NeedPrepare then
+                    do! command.PrepareAsync(props.CancellationToken)
                 use! reader = command.ExecuteReaderAsync(props.CancellationToken)
                 let postgresReader = unbox<NpgsqlDataReader> reader
                 let rowReader = RowReader(postgresReader)
@@ -504,7 +506,8 @@ module Sql =
                 then do! connection.OpenAsync(props.CancellationToken)
                 use command = makeCommand props connection
                 do populateCmd command props
-                if props.NeedPrepare then command.Prepare()
+                if props.NeedPrepare then
+                    do! command.PrepareAsync(props.CancellationToken)
                 use! reader = command.ExecuteReaderAsync props.CancellationToken
                 let postgresReader = unbox<NpgsqlDataReader> reader
                 let rowReader = RowReader(postgresReader)
@@ -547,7 +550,8 @@ module Sql =
                 then do! connection.OpenAsync props.CancellationToken
                 use command = makeCommand props connection
                 populateCmd command props
-                if props.NeedPrepare then command.Prepare()
+                if props.NeedPrepare then
+                    do! command.PrepareAsync(props.CancellationToken)
                 let! affectedRows = command.ExecuteNonQueryAsync props.CancellationToken
                 return affectedRows
             finally


### PR DESCRIPTION
When using the async functions for executing queries we should also use the async version of `NpgsqlCommand.PrepareAsync()`.
Affected functions are `executeAsync`, `iterAsync`, `executeRowAsync`, `executeNonQueryAsync`.